### PR TITLE
fix: export GOPROXY in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ export GOPROXY=https://goproxy.cn
 or
 
 ```bash
-$ echo "GOPROXY=https://goproxy.cn" >> ~/.profile && source ~/.profile
+$ echo "export GOPROXY=https://goproxy.cn" >> ~/.profile && source ~/.profile
 ```
 
 done.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,7 +50,7 @@ $ export GOPROXY=https://goproxy.cn
 或者
 
 ```bash
-$ echo "GOPROXY=https://goproxy.cn" >> ~/.profile && source ~/.profile
+$ echo "export GOPROXY=https://goproxy.cn" >> ~/.profile && source ~/.profile
 ```
 
 完成。


### PR DESCRIPTION
没有 `export` 会导致环境变量中存在 GOPROXY，但是 `go env GOPROXY` 中为空。