### PR TITLE
fix: make config decide the unit of timeout

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,5 +25,5 @@ kodo_bucket_endpoint = "<KODO_BUCKET_ENDPOINT>"
 go_bin_name = "go"
 max_go_bin_workers = 8
 auto_redirect = false
-timeout = 60
+timeout = 60s
 local_cache_root = "/tmp"

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -169,7 +169,7 @@ func proxy(req *air.Request, res *air.Response) error {
 
 	ctx, cancel := context.WithTimeout(
 		req.Context,
-		goproxyViper.GetDuration("timeout")*time.Second,
+		goproxyViper.GetDuration("timeout"),
 	)
 	defer cancel()
 


### PR DESCRIPTION
### Reason

It's better to let the config decide what time unit it will use as a timeout.

### Reference

viper will handles some of the units [by default](https://github.com/spf13/cast/blob/1ffadf551085444af981432dd0f6d1160c11ec64/caste.go#L61)