### PR TITLE
add usage for macOS Catalina(10.15) above

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ $ echo "export GOPROXY=https://goproxy.cn" >> ~/.profile
 $ source ~/.profile
 ```
 
+or macOS Catalina(10.15) above
+
+```zsh
+$ touch ~/.zshrc
+$ echo "export GO111MODULE=on" >> ~/.zshrc
+$ echo "export GOPROXY=https://goproxy.cn" >> ~/.zshrc
+$ source ~/.zshrc
+```
+
 done.
 
 ### Windows


### PR DESCRIPTION
Because macOS changed the default terminal, the usage became different。